### PR TITLE
feat: Add RRM events API support

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@
 //   - /api/v1/sites/:site_id/devices
 //   - /api/v1/sites/:site_id/stats/devices
 //   - /api/v1/sites/:site_id/stats/clients
+//   - /api/v1/sites/:site_id/rrm/events
 package mistclient
 
 import (

--- a/enums.go
+++ b/enums.go
@@ -200,14 +200,31 @@ func (r Radio) String() string {
 	}
 }
 
+// APIString returns the Radio band in the format expected by the Mist API.
+// For Band24 this returns "24" (not "2.4") to match API requirements.
+// Use this method when constructing API requests (query parameters, etc).
+func (r Radio) APIString() string {
+	switch r {
+	case Band6:
+		return "6"
+	case Band5:
+		return "5"
+	case Band24:
+		return "24"
+	default:
+		return "unknown"
+	}
+}
+
 // RadioFromString creates a Radio from the associated string representation.
+// Accepts both "24" (API format) and "2.4" (display format) for Band24.
 func RadioFromString(r string) Radio {
 	switch r {
 	case "6":
 		return Band6
 	case "5":
 		return Band5
-	case "24":
+	case "24", "2.4":
 		return Band24
 	default:
 		return 0

--- a/models.go
+++ b/models.go
@@ -337,9 +337,9 @@ type RRMEvent struct {
 	PreBandwidth int         `json:"pre_bandwidth,omitempty"`
 	PreChannel   int         `json:"pre_channel,omitempty"`
 	PrePower     int         `json:"pre_power,omitempty"`
-	PreUsage     int 	 `json:"pre_usage,omitempty"`
+	PreUsage     Radio       `json:"pre_usage,omitempty"`
 	Timestamp    UnixTime    `json:"timestamp,omitzero"`
-	Usage        int  `json:"usage,omitempty"`
+	Usage        Radio       `json:"usage,omitempty"`
 }
 
 // RRMEventsResponse is the paginated response for RRM events

--- a/models.go
+++ b/models.go
@@ -326,6 +326,31 @@ type Airwatch struct {
 	Authorized bool `json:"authorized,omitempty"`
 }
 
+// RRMEvent represents a radio resource management event
+type RRMEvent struct {
+	APID         string      `json:"ap_id,omitempty"`
+	Band         Radio       `json:"band,omitempty"`
+	Bandwidth    int         `json:"bandwidth,omitempty"`
+	Channel      int         `json:"channel,omitempty"`
+	Event        string      `json:"event,omitempty"`
+	Power        int         `json:"power,omitempty"`
+	PreBandwidth int         `json:"pre_bandwidth,omitempty"`
+	PreChannel   int         `json:"pre_channel,omitempty"`
+	PrePower     int         `json:"pre_power,omitempty"`
+	PreUsage     int 	 `json:"pre_usage,omitempty"`
+	Timestamp    UnixTime    `json:"timestamp,omitzero"`
+	Usage        int  `json:"usage,omitempty"`
+}
+
+// RRMEventsResponse is the paginated response for RRM events
+type RRMEventsResponse struct {
+	Start   int64      `json:"start,omitempty"`
+	End     int64      `json:"end,omitempty"`
+	Limit   int        `json:"limit,omitempty"`
+	Next    string     `json:"next,omitempty"`
+	Results []RRMEvent `json:"results,omitempty"`
+}
+
 // StreamedDeviceStat holds information regarding a device returned by the websockets streaming stats API
 type StreamedDeviceStat struct {
 	Mac        string                            `json:"mac,omitempty"`

--- a/site.go
+++ b/site.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 // GetSiteStats fetches a site's operational statistics
@@ -100,4 +101,35 @@ func (c *APIClient) GetSiteClientStats(siteID string) ([]Client, error) {
 // StreamSiteClientStats opens a websocket connection and subscribes to the client statistics stream
 func (c *APIClient) StreamSiteClientStats(ctx context.Context, siteID string) (<-chan StreamedClientStat, error) {
 	return streamStats[StreamedClientStat](ctx, c, fmt.Sprintf("/sites/%s/stats/clients", siteID))
+}
+
+// GetSiteRRMEvents retrieves RRM events for a site within the specified time range for a specific radio band.
+// Parameters start and end are epoch timestamps. Use limit to control page size (default 100).
+// The band parameter specifies which radio band to query (Band24, Band5, or Band6).
+func (c *APIClient) GetSiteRRMEvents(siteID string, band Radio, start int64, end int64, limit int) (RRMEventsResponse, error) {
+	var response RRMEventsResponse
+
+	u := c.baseURL.JoinPath(fmt.Sprintf("/api/v1/sites/%s/rrm/events", siteID))
+
+	q := u.Query()
+	q.Add("band", band.APIString())
+	q.Add("start", strconv.FormatInt(start, 10))
+	q.Add("end", strconv.FormatInt(end, 10))
+	if limit > 0 {
+		q.Add("limit", strconv.Itoa(limit))
+	}
+	u.RawQuery = q.Encode()
+
+	resp, err := c.Get(u)
+	if err != nil {
+		return response, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return response, extractError(resp)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	return response, err
 }

--- a/site_test.go
+++ b/site_test.go
@@ -181,3 +181,38 @@ func TestGetSiteClients(t *testing.T) {
 		}
 	}
 }
+
+func TestGetSiteRRMEvents(t *testing.T) {
+	c := newTestClient(t)
+
+	siteID := "test-site-id"
+	response, err := c.GetSiteRRMEvents(siteID, Band24, 1428939600, 1428954000, 100)
+	if err != nil {
+		t.Errorf("APIClient.GetSiteRRMEvents(%s): Threw error: %s", siteID, err)
+	}
+
+	if response.Start != 1428939600 {
+		t.Errorf("APIClient.GetSiteRRMEvents(%s).Start: expected 1428939600, got: %d", siteID, response.Start)
+	}
+	if response.End != 1428954000 {
+		t.Errorf("APIClient.GetSiteRRMEvents(%s).End: expected 1428954000, got: %d", siteID, response.End)
+	}
+	if response.Limit != 100 {
+		t.Errorf("APIClient.GetSiteRRMEvents(%s).Limit: expected 100, got: %d", siteID, response.Limit)
+	}
+
+	if len(response.Results) != 1 {
+		t.Errorf("APIClient.GetSiteRRMEvents(%s): expected 1 result, got: %d", siteID, len(response.Results))
+	} else {
+		event := response.Results[0]
+		if event.Channel != 6 {
+			t.Errorf("APIClient.GetSiteRRMEvents(%s)[0].Channel: expected 6, got: %d", siteID, event.Channel)
+		}
+		if event.Band != Band24 {
+			t.Errorf("APIClient.GetSiteRRMEvents(%s)[0].Band: expected Band24, got: %s", siteID, event.Band)
+		}
+		if event.Event != "scheduled-site_rrm" {
+			t.Errorf("APIClient.GetSiteRRMEvents(%s)[0].Event: expected 'scheduled-site_rrm', got: %s", siteID, event.Event)
+		}
+	}
+}

--- a/testdata/api/v1/sites/test-site-id/rrm/events
+++ b/testdata/api/v1/sites/test-site-id/rrm/events
@@ -1,0 +1,22 @@
+{
+  "end": 1428954000,
+  "limit": 100,
+  "next": "/api/v1/sites/dca0a44b-324c-11e6-a776-0243ad110007/events/rrm?start=1428939600&end=1428949600&limit=200&token=001a0010000000120010000005005880ec18000004776c616e007fffffeb067ab8e29c1d659b6a7c8cf698bf81490003",
+  "results": [
+    {
+      "ap_id": "01-a2-b3-c4-e5-ff",
+      "band": "24",
+      "bandwidth": 20,
+      "channel": 6,
+      "event": "scheduled-site_rrm",
+      "power": 5,
+      "pre_bandwidth": 20,
+      "pre_channel": 1,
+      "pre_power": 11,
+      "pre_usage": "24",
+      "timestamp": 1428939600,
+      "usage": "24"
+    }
+  ],
+  "start": 1428939600
+}


### PR DESCRIPTION
This commit introduces support for the Mist Radio Resource Management (RRM) events API endpoint, enabling retrieval of radio configuration change events for access points.

Key changes:

- Added GetSiteRRMEvents() method to retrieve RRM events for a specific site, radio band, and time range with pagination support

- Introduced RRMEvent model to represent radio resource management events, including channel, bandwidth, power changes and usage metrics

- Added RRMEventsResponse model for paginated API responses with start, end, limit, and next cursor fields

- Enhanced Radio enum with APIString() method that returns API-compatible band format ("24" instead of "2.4" for 2.4GHz band)

- Updated RadioFromString() to accept both API format ("24") and display format ("2.4") for better flexibility

- Added comprehensive test coverage in TestGetSiteRRMEvents() validating response parsing and field mappings

- Updated package documentation to include new RRM events endpoint

The RRM events endpoint provides visibility into automated and manual radio configuration changes, useful for monitoring network optimization activities.